### PR TITLE
Registration file tests and small fixes

### DIFF
--- a/changelog.d/34.bugfix
+++ b/changelog.d/34.bugfix
@@ -1,0 +1,1 @@
+Fix issue where `AppServiceRegistration.getOutput()` would fail if `de.sorunome.msc2409.push_ephemeral` is undefined.

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,12 @@
         "@types/node": "*"
       }
     },
+    "@types/chai": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
+      "integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -144,6 +150,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
       "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
+    },
+    "@types/mocha": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
+      "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
+      "dev": true
     },
     "@types/morgan": {
       "version": "1.9.1",
@@ -283,6 +295,12 @@
         "eslint-visitor-keys": "^1.1.0"
       }
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -337,6 +355,22 @@
         "color-convert": "^1.9.0"
       }
     },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -349,6 +383,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -375,6 +415,12 @@
       "requires": {
         "safe-buffer": "5.1.2"
       }
+    },
+    "binary-extensions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -403,6 +449,27 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -413,6 +480,26 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
     },
     "chalk": {
       "version": "4.1.0",
@@ -462,6 +549,56 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      }
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -529,6 +666,21 @@
         "ms": "2.0.0"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -544,6 +696,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -808,6 +966,15 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -821,6 +988,22 @@
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       }
+    },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "flat-cache": {
       "version": "2.0.1",
@@ -867,10 +1050,29 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "glob": {
@@ -911,6 +1113,12 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.7.6",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
@@ -928,6 +1136,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "highlight.js": {
@@ -1004,6 +1218,15 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1024,6 +1247,18 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -1078,16 +1313,40 @@
         "type-check": "~0.4.0"
       }
     },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0"
+      }
+    },
     "lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "marked": {
@@ -1153,6 +1412,77 @@
         "minimist": "^1.2.5"
       }
     },
+    "mocha": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.0.tgz",
+      "integrity": "sha512-lEWEMq2LMfNJMKeuEwb5UELi+OgFDollXaytR5ggQcHpzG3NP/R7rvixAvF+9/lLsTWhWG+4yD2M70GsM06nxw==",
+      "dev": true,
+      "requires": {
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.4.3",
+        "debug": "4.2.0",
+        "diff": "4.0.2",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.14.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.2",
+        "nanoid": "3.1.12",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "7.2.0",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.0.2",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -1177,6 +1507,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -1192,6 +1528,12 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
     "on-finished": {
@@ -1230,6 +1572,30 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "p-limit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+      "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -1243,6 +1609,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1266,6 +1638,18 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -1299,6 +1683,15 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1315,6 +1708,15 @@
         "unpipe": "1.0.0"
       }
     },
+    "readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -1328,6 +1730,18 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "resolve": {
@@ -1397,6 +1811,15 @@
         }
       }
     },
+    "serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "serve-static": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
@@ -1407,6 +1830,12 @@
         "parseurl": "~1.3.3",
         "send": "0.17.1"
       }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -1455,6 +1884,16 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1536,10 +1975,32 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "ts-node": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.0.0.tgz",
+      "integrity": "sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
     },
     "tslib": {
       "version": "1.13.0",
@@ -1564,6 +2025,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",
@@ -1663,6 +2130,48 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -1674,6 +2183,40 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "workerpool": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+      "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -1689,6 +2232,117 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        }
+      }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "gendoc": "typedoc",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha -r ts-node/register test/*.ts",
     "lint": "eslint -c .eslintrc --max-warnings 0 src/**/*.ts",
     "build": "tsc --project tsconfig.json",
     "prepare": "npm run build"
@@ -31,12 +31,17 @@
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.0",
+    "@types/chai": "^4.2.14",
     "@types/js-yaml": "^3.12.5",
+    "@types/mocha": "^8.0.3",
     "@types/morgan": "^1.9.1",
     "@types/node": "^10.17.29",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
+    "chai": "^4.2.0",
     "eslint": "^7.8.1",
+    "mocha": "^8.2.0",
+    "ts-node": "^9.0.0",
     "typedoc": "^0.19.1",
     "typescript": "^3.9.7"
   }

--- a/src/app-service-registration.ts
+++ b/src/app-service-registration.ts
@@ -208,26 +208,43 @@ export class AppServiceRegistration {
 
     /**
      * Get the key-value output which should be written to a YAML file.
-     * @return {Object}
      * @throws If required fields hs_token, as-token, url, sender_localpart are missing.
      */
-    public getOutput() {
-        if (!this.id || !this.hsToken || !this.asToken || !this.url || !this.senderLocalpart) {
+    public getOutput(): AppServiceOutput {
+        // Typescript will default any string array to a set of strings, even if it's a static array.
+        const requiredFields: ("id"|"hsToken"|"asToken"|"senderLocalpart")[] = [
+            "id", "hsToken", "asToken", "senderLocalpart"
+        ];
+        const missingFields = requiredFields.filter((key) => !this[key]);
+        if (missingFields.length) {
             throw new Error(
-                "Missing required field(s): id, hs_token, as_token, url, sender_localpart"
+                `Missing required field(s): ${missingFields}`
             );
         }
-        return {
-            id: this.id,
-            hs_token: this.hsToken,
-            as_token: this.asToken,
-            namespaces: this.namespaces,
+        const responseFormat: AppServiceOutput = {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            id: this.id!,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            hs_token: this.hsToken!,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            as_token: this.asToken!,
             url: this.url,
-            sender_localpart: this.senderLocalpart,
-            rate_limited: this.rateLimited,
-            protocols: this.protocols,
-            "de.sorunome.msc2409.push_ephemeral": this.pushEphemeral,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            sender_localpart: this.senderLocalpart!,
         };
+        if (this.pushEphemeral !== undefined) {
+            responseFormat["de.sorunome.msc2409.push_ephemeral"] = this.pushEphemeral;
+        }
+        if (this.protocols) {
+            responseFormat.protocols = this.protocols;
+        }
+        if (Object.keys(this.namespaces).length > 0) {
+            responseFormat.namespaces = this.namespaces;
+        }
+        if(this.rateLimited !== undefined) {
+            responseFormat.rate_limited = this.rateLimited;
+        }
+        return responseFormat;
     }
 
     /**

--- a/src/app-service-registration.ts
+++ b/src/app-service-registration.ts
@@ -83,6 +83,13 @@ export class AppServiceRegistration {
     }
 
     /**
+     * Get the URL which the home server will hit in order to talk to the AS.
+     */
+    public getAppServiceUrl() {
+        return this.url;
+    }
+
+    /**
      * Set the ID of the appservice; must be unique across the homeserver and never change.
      * @param {string} id The ID
      */
@@ -153,6 +160,13 @@ export class AppServiceRegistration {
      */
     public setSenderLocalpart(localpart: string) {
         this.senderLocalpart = localpart;
+    }
+
+    /**
+     * Get whether requests from this AS are rate-limited by the home server.
+     */
+    public isRateLimited() {
+        return this.rateLimited === undefined ? true : this.rateLimited;
     }
 
     /**

--- a/src/app-service-registration.ts
+++ b/src/app-service-registration.ts
@@ -26,9 +26,6 @@ export class AppServiceRegistration {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public static fromObject(obj: any): AppServiceRegistration|null {
-        if (!obj.url) {
-            return null;
-        }
         const reg = new AppServiceRegistration(obj.url);
         reg.setId(obj.id);
         reg.setHomeserverToken(obj.hs_token);
@@ -75,7 +72,7 @@ export class AppServiceRegistration {
     } = { users: [], aliases: [], rooms: []};
     private protocols: string[]|null = null;
     private cachedRegex: {[regextext: string]: RegExp} = {};
-    constructor (private url: string) { }
+    constructor (private url: string|null) { }
 
     /**
      * Set the URL which the home server will hit in order to talk to the AS.

--- a/src/app-service-registration.ts
+++ b/src/app-service-registration.ts
@@ -198,6 +198,16 @@ export class AppServiceRegistration {
     }
 
     /**
+     * **Experimental**
+     * 
+     * Should the appservice receive ephemeral events. Note this requires
+     * a homeserver implementing MSC2409.
+     */
+    public pushEphemeralEnabled() {
+        return this.pushEphemeral || false;
+    }
+
+    /**
      * Get the desired user_id localpart for the app service itself.
      * @return {?string} The user_id localpart ("alice" in "@alice:domain")
      */

--- a/src/app-service-registration.ts
+++ b/src/app-service-registration.ts
@@ -59,12 +59,12 @@ export class AppServiceRegistration {
     private hsToken: string|null = null;
     private asToken: string|null = null;
     private senderLocalpart: string|null = null;
-    private rateLimited = true;
+    private rateLimited: boolean|undefined = undefined;
     /**
      * **Experimental**  
      * Signal to the homeserver that this appservice will accept ephemeral events.
      */
-    public pushEphemeral = false;
+    public pushEphemeral: boolean|undefined = undefined;
     private namespaces: {
         users?: RegexObj[];
         aliases?: RegexObj[];

--- a/src/app-service-registration.ts
+++ b/src/app-service-registration.ts
@@ -66,10 +66,10 @@ export class AppServiceRegistration {
      */
     public pushEphemeral = false;
     private namespaces: {
-        users: RegexObj[];
-        aliases: RegexObj[];
-        rooms: RegexObj[];
-    } = { users: [], aliases: [], rooms: []};
+        users?: RegexObj[];
+        aliases?: RegexObj[];
+        rooms?: RegexObj[];
+    } = {};
     private protocols: string[]|null = null;
     private cachedRegex: {[regextext: string]: RegExp} = {};
     constructor (private url: string|null) { }
@@ -207,7 +207,12 @@ export class AppServiceRegistration {
             regex: regex
         };
 
-        this.namespaces[type].push(regexObject);
+        const namespace = this.namespaces[type];
+        if (namespace) {
+            namespace.push(regexObject);
+        } else {
+            this.namespaces[type] = [regexObject];
+        }
     }
 
     /**
@@ -294,7 +299,10 @@ export class AppServiceRegistration {
         return this._isMatch(this.namespaces.rooms, roomId, onlyExclusive);
     }
 
-    public _isMatch(regexList: RegexObj[], sample: string, onlyExclusive: boolean) {
+    public _isMatch(regexList: RegexObj[]|undefined, sample: string, onlyExclusive: boolean) {
+        if (!regexList) {
+            return false;
+        }
         onlyExclusive = Boolean(onlyExclusive);
         for (const regexObj of regexList) {
             let regex = this.cachedRegex[regexObj.regex];

--- a/test/test_app-service-registration.ts
+++ b/test/test_app-service-registration.ts
@@ -1,0 +1,117 @@
+import { AppServiceRegistration } from "../src/app-service-registration"; 
+import { expect } from "chai";
+
+describe("AppServiceRegistration", () => {
+    it("can construct a fresh registration file", () => {
+        const reg = new AppServiceRegistration("https://example.com");
+        expect(reg.getAppServiceUrl()).to.equal("https://example.com");
+    });
+    it("can import minimal registration from object", () => {
+        const reg = AppServiceRegistration.fromObject({
+            id: "foobar",
+            hs_token: "foohstoken",
+            as_token: "fooastoken",
+            url: "https://example.com",
+            sender_localpart: "foobot",
+        });
+        expect(reg.getId()).to.equal("foobar");
+        expect(reg.getHomeserverToken()).to.equal("foohstoken");
+        expect(reg.getAppServiceToken()).to.equal("fooastoken");
+        expect(reg.getAppServiceUrl()).to.equal("https://example.com");
+        expect(reg.getSenderLocalpart()).to.equal("foobot");
+        expect(reg.getProtocols()).to.be.null;
+        expect(reg.isRateLimited()).to.be.true;
+        expect(reg.pushEphemeral).to.be.undefined;
+    });
+    it("can import complete registration from object", () => {
+        const reg = AppServiceRegistration.fromObject({
+            id: "foobar",
+            hs_token: "foohstoken",
+            as_token: "fooastoken",
+            url: "https://example.com",
+            sender_localpart: "foobot",
+            protocols: ["irc", "gitter"],
+            "de.sorunome.msc2409.push_ephemeral": true,
+            rate_limited: false,
+            namespaces: {
+                users: [{
+                    regex: "@foobar.+",
+                    exclusive: true,
+                },{
+                    regex: "@barbaz.+",
+                    exclusive: false,
+                }],
+                rooms: [{
+                    regex: "!foo",
+                    exclusive: true,
+                }],
+                aliases: [{
+                    regex: "#foo.+",
+                    exclusive: true,
+                }]
+            }
+        });
+        expect(reg.getId()).to.equal("foobar");
+        expect(reg.getHomeserverToken()).to.equal("foohstoken");
+        expect(reg.getAppServiceToken()).to.equal("fooastoken");
+        expect(reg.getAppServiceUrl()).to.equal("https://example.com");
+        expect(reg.getSenderLocalpart()).to.equal("foobot");
+        expect(reg.getProtocols()).to.deep.equal(["irc", "gitter"]);
+        expect(reg.isRateLimited()).to.be.false;
+        expect(reg.pushEphemeral).to.be.true;
+
+        expect(reg.isRoomMatch("!foo", true)).to.be.true;
+
+        expect(reg.isUserMatch("@foobar1", true)).to.be.true;
+        expect(reg.isUserMatch("@foobar2", false)).to.be.true;
+        expect(reg.isUserMatch("@barbaz1", false)).to.be.true;
+
+        expect(reg.isAliasMatch("#foo1", true)).to.be.true;
+        expect(reg.isAliasMatch("#foo1", false)).to.be.true;
+    });
+    it("can export minimal registration to object", () => {
+        const input = {
+            id: "foobar",
+            hs_token: "foohstoken",
+            as_token: "fooastoken",
+            url: null,
+            sender_localpart: "foobot",
+        }
+        const reg = AppServiceRegistration.fromObject(input);
+        const output = reg.getOutput();
+        expect(output).to.deep.equal(input);
+    });
+    it("can complete minimal registration to object", () => {
+        const input = {
+            id: "foobar",
+            hs_token: "foohstoken",
+            as_token: "fooastoken",
+            url: "https://example.com",
+            sender_localpart: "foobot",
+            protocols: ["irc", "gitter"],
+            "de.sorunome.msc2409.push_ephemeral": true,
+            rate_limited: false,
+            namespaces: {
+                users: [{
+                    regex: "@foobar.+",
+                    exclusive: true,
+                },{
+                    regex: "@barbaz.+",
+                    exclusive: false,
+                }],
+                rooms: [{
+                    regex: "!foo",
+                    exclusive: true,
+                }],
+                aliases: [{
+                    regex: "#foo.+",
+                    exclusive: true,
+                }]
+            }
+
+        }
+        const reg = AppServiceRegistration.fromObject(input);
+        const output = reg.getOutput();
+        expect(output).to.deep.equal(input);
+    });
+})

--- a/test/test_app-service-registration.ts
+++ b/test/test_app-service-registration.ts
@@ -23,6 +23,7 @@ describe("AppServiceRegistration", () => {
             expect(reg.getProtocols()).to.be.null;
             expect(reg.isRateLimited()).to.be.true;
             expect(reg.pushEphemeral).to.be.undefined;
+            expect(reg.pushEphemeralEnabled()).to.be.false;
         });
 
         it("can import complete registration from object", () => {
@@ -61,6 +62,7 @@ describe("AppServiceRegistration", () => {
             expect(reg.getProtocols()).to.deep.equal(["irc", "gitter"]);
             expect(reg.isRateLimited()).to.be.false;
             expect(reg.pushEphemeral).to.be.true;
+            expect(reg.pushEphemeralEnabled()).to.be.true;
     
             expect(reg.isRoomMatch("!foo", true)).to.be.true;
     

--- a/test/test_app-service-registration.ts
+++ b/test/test_app-service-registration.ts
@@ -6,112 +6,127 @@ describe("AppServiceRegistration", () => {
         const reg = new AppServiceRegistration("https://example.com");
         expect(reg.getAppServiceUrl()).to.equal("https://example.com");
     });
-    it("can import minimal registration from object", () => {
-        const reg = AppServiceRegistration.fromObject({
-            id: "foobar",
-            hs_token: "foohstoken",
-            as_token: "fooastoken",
-            url: "https://example.com",
-            sender_localpart: "foobot",
+    describe("fromObject", () => {
+        it("can import minimal registration from object", () => {
+            const reg = AppServiceRegistration.fromObject({
+                id: "foobar",
+                hs_token: "foohstoken",
+                as_token: "fooastoken",
+                url: "https://example.com",
+                sender_localpart: "foobot",
+            });
+            expect(reg.getId()).to.equal("foobar");
+            expect(reg.getHomeserverToken()).to.equal("foohstoken");
+            expect(reg.getAppServiceToken()).to.equal("fooastoken");
+            expect(reg.getAppServiceUrl()).to.equal("https://example.com");
+            expect(reg.getSenderLocalpart()).to.equal("foobot");
+            expect(reg.getProtocols()).to.be.null;
+            expect(reg.isRateLimited()).to.be.true;
+            expect(reg.pushEphemeral).to.be.undefined;
         });
-        expect(reg.getId()).to.equal("foobar");
-        expect(reg.getHomeserverToken()).to.equal("foohstoken");
-        expect(reg.getAppServiceToken()).to.equal("fooastoken");
-        expect(reg.getAppServiceUrl()).to.equal("https://example.com");
-        expect(reg.getSenderLocalpart()).to.equal("foobot");
-        expect(reg.getProtocols()).to.be.null;
-        expect(reg.isRateLimited()).to.be.true;
-        expect(reg.pushEphemeral).to.be.undefined;
+
+        it("can import complete registration from object", () => {
+            const reg = AppServiceRegistration.fromObject({
+                id: "foobar",
+                hs_token: "foohstoken",
+                as_token: "fooastoken",
+                url: "https://example.com",
+                sender_localpart: "foobot",
+                protocols: ["irc", "gitter"],
+                "de.sorunome.msc2409.push_ephemeral": true,
+                rate_limited: false,
+                namespaces: {
+                    users: [{
+                        regex: "@foobar.+",
+                        exclusive: true,
+                    },{
+                        regex: "@barbaz.+",
+                        exclusive: false,
+                    }],
+                    rooms: [{
+                        regex: "!foo",
+                        exclusive: true,
+                    }],
+                    aliases: [{
+                        regex: "#foo.+",
+                        exclusive: true,
+                    }]
+                }
+            });
+            expect(reg.getId()).to.equal("foobar");
+            expect(reg.getHomeserverToken()).to.equal("foohstoken");
+            expect(reg.getAppServiceToken()).to.equal("fooastoken");
+            expect(reg.getAppServiceUrl()).to.equal("https://example.com");
+            expect(reg.getSenderLocalpart()).to.equal("foobot");
+            expect(reg.getProtocols()).to.deep.equal(["irc", "gitter"]);
+            expect(reg.isRateLimited()).to.be.false;
+            expect(reg.pushEphemeral).to.be.true;
+    
+            expect(reg.isRoomMatch("!foo", true)).to.be.true;
+    
+            expect(reg.isUserMatch("@foobar1", true)).to.be.true;
+            expect(reg.isUserMatch("@foobar2", false)).to.be.true;
+            expect(reg.isUserMatch("@barbaz1", false)).to.be.true;
+    
+            expect(reg.isAliasMatch("#foo1", true)).to.be.true;
+            expect(reg.isAliasMatch("#foo1", false)).to.be.true;
+        });    
     });
-    it("can import complete registration from object", () => {
-        const reg = AppServiceRegistration.fromObject({
-            id: "foobar",
-            hs_token: "foohstoken",
-            as_token: "fooastoken",
-            url: "https://example.com",
-            sender_localpart: "foobot",
-            protocols: ["irc", "gitter"],
-            "de.sorunome.msc2409.push_ephemeral": true,
-            rate_limited: false,
-            namespaces: {
-                users: [{
-                    regex: "@foobar.+",
-                    exclusive: true,
-                },{
-                    regex: "@barbaz.+",
-                    exclusive: false,
-                }],
-                rooms: [{
-                    regex: "!foo",
-                    exclusive: true,
-                }],
-                aliases: [{
-                    regex: "#foo.+",
-                    exclusive: true,
-                }]
-            }
+    describe("getOutput", () => {
+        it("can export minimal registration to object", () => {
+            const reg = new AppServiceRegistration(null);
+            reg.setId("foobar");
+            reg.setHomeserverToken("foohstoken");
+            reg.setAppServiceToken("fooastoken");
+            reg.setSenderLocalpart("foobot");
+            expect(reg.getOutput()).to.deep.equal({
+                id: "foobar",
+                hs_token: "foohstoken",
+                as_token: "fooastoken",
+                url: null,
+                sender_localpart: "foobot",
+            });
         });
-        expect(reg.getId()).to.equal("foobar");
-        expect(reg.getHomeserverToken()).to.equal("foohstoken");
-        expect(reg.getAppServiceToken()).to.equal("fooastoken");
-        expect(reg.getAppServiceUrl()).to.equal("https://example.com");
-        expect(reg.getSenderLocalpart()).to.equal("foobot");
-        expect(reg.getProtocols()).to.deep.equal(["irc", "gitter"]);
-        expect(reg.isRateLimited()).to.be.false;
-        expect(reg.pushEphemeral).to.be.true;
-
-        expect(reg.isRoomMatch("!foo", true)).to.be.true;
-
-        expect(reg.isUserMatch("@foobar1", true)).to.be.true;
-        expect(reg.isUserMatch("@foobar2", false)).to.be.true;
-        expect(reg.isUserMatch("@barbaz1", false)).to.be.true;
-
-        expect(reg.isAliasMatch("#foo1", true)).to.be.true;
-        expect(reg.isAliasMatch("#foo1", false)).to.be.true;
-    });
-    it("can export minimal registration to object", () => {
-        const input = {
-            id: "foobar",
-            hs_token: "foohstoken",
-            as_token: "fooastoken",
-            url: null,
-            sender_localpart: "foobot",
-        }
-        const reg = AppServiceRegistration.fromObject(input);
-        const output = reg.getOutput();
-        expect(output).to.deep.equal(input);
-    });
-    it("can complete minimal registration to object", () => {
-        const input = {
-            id: "foobar",
-            hs_token: "foohstoken",
-            as_token: "fooastoken",
-            url: "https://example.com",
-            sender_localpart: "foobot",
-            protocols: ["irc", "gitter"],
-            "de.sorunome.msc2409.push_ephemeral": true,
-            rate_limited: false,
-            namespaces: {
-                users: [{
-                    regex: "@foobar.+",
-                    exclusive: true,
-                },{
-                    regex: "@barbaz.+",
-                    exclusive: false,
-                }],
-                rooms: [{
-                    regex: "!foo",
-                    exclusive: true,
-                }],
-                aliases: [{
-                    regex: "#foo.+",
-                    exclusive: true,
-                }]
-            }
-
-        }
-        const reg = AppServiceRegistration.fromObject(input);
-        const output = reg.getOutput();
-        expect(output).to.deep.equal(input);
+        it("can export complete registration to object", () => {
+            const reg = new AppServiceRegistration("https://example.com");
+            reg.setId("foobar");
+            reg.setHomeserverToken("foohstoken");
+            reg.setAppServiceToken("fooastoken");
+            reg.setSenderLocalpart("foobot");
+            reg.setRateLimited(false);
+            reg.setProtocols(["irc", "gitter"]);
+            reg.pushEphemeral = true;
+            reg.addRegexPattern("users", "@foobar.+", true);
+            reg.addRegexPattern("users", "@barbaz.+", false);
+            reg.addRegexPattern("rooms", "!foo", true);
+            reg.addRegexPattern("aliases", "#foo.+", true);
+            expect(reg.getOutput()).to.deep.equal({
+                id: "foobar",
+                hs_token: "foohstoken",
+                as_token: "fooastoken",
+                url: "https://example.com",
+                sender_localpart: "foobot",
+                protocols: ["irc", "gitter"],
+                "de.sorunome.msc2409.push_ephemeral": true,
+                rate_limited: false,
+                namespaces: {
+                    users: [{
+                        regex: "@foobar.+",
+                        exclusive: true,
+                    },{
+                        regex: "@barbaz.+",
+                        exclusive: false,
+                    }],
+                    rooms: [{
+                        regex: "!foo",
+                        exclusive: true,
+                    }],
+                    aliases: [{
+                        regex: "#foo.+",
+                        exclusive: true,
+                    }]
+                }
+            });
+        });
     });
 })


### PR DESCRIPTION
Fixes #33 

This may best be reviewed commit by commit. This change:

- Allows `url` to be `null` as per spec https://matrix.org/docs/spec/application_service/r0.1.2#registration
- Trims the output of `getOutput` to not return empty fields, also per spec.
- Does not break if optional fields are not defined
- Adds a few getters for some properties.
- Adds tests for the registration object.
