### PR TITLE
Rename master -> develop

### DIFF
--- a/changelog.d/40.misc
+++ b/changelog.d/40.misc
@@ -1,0 +1,1 @@
+The `master` branch has been renamed to `develop` to be consistent wih other `matrix-org` projects.

--- a/scripts/changelog-check.sh
+++ b/scripts/changelog-check.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 pip3 install towncrier==19.2.0
-python3 -m towncrier.check --compare-with=origin/master
+python3 -m towncrier.check --compare-with=origin/develop


### PR DESCRIPTION
So that we can align with other matrix projects which use develop to mean bleeding edge. We don't have a "stable" branch on this project, and users who want stability should be using versioned releases anyway.