### PR TITLE
Redirect legacy endpoints

### DIFF
--- a/changelog.d/63.removal
+++ b/changelog.d/63.removal
@@ -1,0 +1,2 @@
+The legacy `/users`, `/rooms`, and `/transactions` endpoints have been removed in this release
+and now redirect to the appropriate spec'd path.

--- a/src/app-service.ts
+++ b/src/app-service.ts
@@ -86,13 +86,13 @@ export class AppService extends EventEmitter {
         app.use(bodyParser.json({
             limit: this.config.httpMaxSizeBytes || MAX_SIZE_BYTES,
         }));
-
+        const legacyEndpointHandler = (req, res) => res.status(308).redirect("/_matrix/app/v1" + req.originalUrl).send({ errcode: "M_UNKNOWN", error: "This non-standard endpoint has been removed" });
         app.get("/_matrix/app/v1/users/:userId", this.onGetUsers.bind(this));
         app.get("/_matrix/app/v1/rooms/:alias", this.onGetRoomAlias.bind(this));
         app.put("/_matrix/app/v1/transactions/:txnId", this.onTransaction.bind(this));
-        app.get("/users/:userId", this.onGetUsers.bind(this));
-        app.get("/rooms/:alias", this.onGetRoomAlias.bind(this));
-        app.put("/transactions/:txnId", this.onTransaction.bind(this));
+        app.get("/users/:userId", legacyEndpointHandler);
+        app.get("/rooms/:alias", legacyEndpointHandler);
+        app.put("/transactions/:txnId", legacyEndpointHandler);
         app.get("/health", this.onHealthCheck.bind(this));
 
         this.app = app;

--- a/src/app-service.ts
+++ b/src/app-service.ts
@@ -86,7 +86,8 @@ export class AppService extends EventEmitter {
         app.use(bodyParser.json({
             limit: this.config.httpMaxSizeBytes || MAX_SIZE_BYTES,
         }));
-        const legacyEndpointHandler = (req, res) => res.status(308).redirect("/_matrix/app/v1" + req.originalUrl).send({ errcode: "M_UNKNOWN", error: "This non-standard endpoint has been removed" });
+        const legacyEndpointHandler = (req: Request, res: Response) => {
+            res.status(308).location("/_matrix/app/v1" + req.originalUrl).send({ errcode: "M_UNKNOWN", error: "This non-standard endpoint has been removed" }) };
         app.get("/_matrix/app/v1/users/:userId", this.onGetUsers.bind(this));
         app.get("/_matrix/app/v1/rooms/:alias", this.onGetRoomAlias.bind(this));
         app.put("/_matrix/app/v1/transactions/:txnId", this.onTransaction.bind(this));


### PR DESCRIPTION
These endpoints are not to be used, and we should start breaking their usage. The redirect is a courtesy so users know what to fix.