### PR TITLE
Wrap towncrier version range in quotes

### DIFF
--- a/.github/workflows/newsfile.yml
+++ b/.github/workflows/newsfile.yml
@@ -13,6 +13,6 @@ jobs:
         with: # Needed for comparison
           fetch-depth: 0
       - uses: actions/setup-python@v2
-      - run: pip install towncrier>=23.6.0
+      - run: pip install 'towncrier>=23.6.0'
       - name: ":newspaper: Newsfile"
         run: ./scripts/check-newsfragment


### PR DESCRIPTION
Otherwise, the > is used as a redirection operator