### PR TITLE
Read ephemeral events from the stable transaction key

### DIFF
--- a/changelog.d/84.bugfix
+++ b/changelog.d/84.bugfix
@@ -1,0 +1,1 @@
+Read ephemeral events from the stable `ephemeral` transaction key, falling back to the unstable MSC2409 key. Fixes ephemeral events (typing, receipts, presence) being dropped from spec-compliant homeservers.

--- a/src/app-service.ts
+++ b/src/app-service.ts
@@ -287,7 +287,7 @@ export class AppService extends EventEmitter {
         const events = req.body.events || [];
         // Ephemeral events are delivered under the stable `ephemeral` key by
         // spec-compliant homeservers; fall back to the unstable MSC2409 key for
-        // older ones. See https://spec.matrix.org/v1.11/application-service-api/#put_matrixappv1transactionstxnid
+        // older ones. See https://spec.matrix.org/v1.13/application-service-api/#put_matrixappv1transactionstxnid
         const ephemeral = req.body.ephemeral || req.body["de.sorunome.msc2409.ephemeral"] || [];
 
         if (this.lastProcessedTxnId === txnId) {

--- a/src/app-service.ts
+++ b/src/app-service.ts
@@ -285,7 +285,10 @@ export class AppService extends EventEmitter {
         }
 
         const events = req.body.events || [];
-        const ephemeral = req.body["de.sorunome.msc2409.ephemeral"] || [];
+        // Ephemeral events are delivered under the stable `ephemeral` key by
+        // spec-compliant homeservers; fall back to the unstable MSC2409 key for
+        // older ones. See https://spec.matrix.org/v1.11/application-service-api/#put_matrixappv1transactionstxnid
+        const ephemeral = req.body.ephemeral || req.body["de.sorunome.msc2409.ephemeral"] || [];
 
         if (this.lastProcessedTxnId === txnId) {
             res.send({}); // duplicate

--- a/test/test_app-service.ts
+++ b/test/test_app-service.ts
@@ -1,0 +1,52 @@
+import { AppService } from "../src/app-service";
+import { expect } from "chai";
+import { Request, Response } from "express";
+
+const HS_TOKEN = "hstoken";
+
+function mockReq(txnId: string, body: unknown): Request {
+    return {
+        params: { txnId },
+        query: { access_token: HS_TOKEN },
+        headers: {},
+        body,
+    } as unknown as Request;
+}
+
+function mockRes(): Response {
+    return {
+        status() { return this; },
+        send() { return this; },
+    } as unknown as Response;
+}
+
+describe("AppService", () => {
+    describe("onTransaction ephemeral events", () => {
+        function receive(body: unknown): Record<string, unknown>[] {
+            const appservice = new AppService({ homeserverToken: HS_TOKEN });
+            const received: Record<string, unknown>[] = [];
+            appservice.on("ephemeral", (ev) => received.push(ev));
+            // onTransaction is private; exercise it directly with a valid token
+            (appservice as unknown as { onTransaction: (req: Request, res: Response) => void })
+                .onTransaction(mockReq("1", body), mockRes());
+            return received;
+        }
+
+        it("emits ephemeral events sent under the stable `ephemeral` key", () => {
+            const receipt = { type: "m.receipt", content: {} };
+            expect(receive({ ephemeral: [receipt] })).to.deep.equal([receipt]);
+        });
+
+        it("still emits ephemeral events under the unstable MSC2409 key", () => {
+            const receipt = { type: "m.receipt", content: {} };
+            expect(receive({ "de.sorunome.msc2409.ephemeral": [receipt] })).to.deep.equal([receipt]);
+        });
+
+        it("prefers the stable key when both are present", () => {
+            const stable = { type: "m.receipt", content: { stable: true } };
+            const unstable = { type: "m.receipt", content: { stable: false } };
+            expect(receive({ ephemeral: [stable], "de.sorunome.msc2409.ephemeral": [unstable] }))
+                .to.deep.equal([stable]);
+        });
+    });
+});

--- a/test/test_app-service.ts
+++ b/test/test_app-service.ts
@@ -32,13 +32,17 @@ describe("AppService", () => {
             return received;
         }
 
+        function mockReceipt() {
+            return { type: "m.receipt", content: { "!e:example.org": { "m.read": { "@u:example.org": { ts: Date.now() } } } } };
+        }
+
         it("emits ephemeral events sent under the stable `ephemeral` key", () => {
-            const receipt = { type: "m.receipt", content: {} };
+            const receipt = mockReceipt();
             expect(receive({ ephemeral: [receipt] })).to.deep.equal([receipt]);
         });
 
         it("still emits ephemeral events under the unstable MSC2409 key", () => {
-            const receipt = { type: "m.receipt", content: {} };
+            const receipt = mockReceipt();
             expect(receive({ "de.sorunome.msc2409.ephemeral": [receipt] })).to.deep.equal([receipt]);
         });
 


### PR DESCRIPTION
### Description

Ephemeral events (typing, receipts, presence) are delivered to application services under the stable `ephemeral` key in the transaction body, per the [Matrix application service spec](https://spec.matrix.org/v1.11/application-service-api/#put_matrixappv1transactionstxnid) (the stabilisation of [MSC2409](https://github.com/matrix-org/matrix-spec-proposals/pull/2409)). However `AppService.onTransaction` only reads the legacy unstable key `de.sorunome.msc2409.ephemeral`.

As a result, ephemeral events from spec-compliant homeservers are silently dropped — `onEphemeralEvent` / the `ephemeral` emitter never fire. I hit this building a bridge against Beeper's hungryserv (which sends the stable key): read receipts and typing never reached the bridge. Synapse also sends the stable key.

### Change

Read `req.body.ephemeral` first, falling back to `req.body["de.sorunome.msc2409.ephemeral"]` for older homeservers. Adds tests covering both keys and the precedence.

`npm run build`, lint, and `npm test` all pass.

Signed-off-by: Lê Quốc Bình <lequocbinh04@users.noreply.github.com>